### PR TITLE
do not add python_abi to runtime requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,10 @@ requirements:
     - mpc
     #- zlib
     - file
+  ignore_run_exports:
+    # nothing links against libpython, the build scripts just don't work out
+    # of the box if you split the libs into build/host
+    - python_abi
 
 test:
   commands:


### PR DESCRIPTION
python_abi is being added to runtime requirements becaue we have everything here in requirements.build instead of splitting the host dependencies out

Doing that causes conda-build to apply all of the 'run_exports' requirements.

I don't think anything in riscv-tools links against the x86 python_abi. So, removing this should allow users to bump the version of python without needing to rebuild riscv-tools.

I don't have write perms on this repo so I forked to create this PR.  Hope it is still useful.