### PR TITLE
ignore_run_exports from python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ requirements:
   ignore_run_exports:
     # nothing links against libpython, the build scripts just don't work out
     # of the box if you split the libs into build/host
-    - python_abi
+    - python
 
 test:
   commands:


### PR DESCRIPTION
ignore_run_exports has to list the package that is injecting the run requirement, not the requirement that is being injected.