### PR TITLE
Enable multilib support

### DIFF
--- a/build-toolchains.sh
+++ b/build-toolchains.sh
@@ -103,7 +103,7 @@ case ${MAKE_VER} in
 esac
 
 echo '==>  Building GNU/Linux toolchain'
-module_build riscv-gnu-toolchain --prefix="${RISCV}" --with-cmodel=medany ${ARCH:+--with-arch=${ARCH}}
+module_build riscv-gnu-toolchain --prefix="${RISCV}" --enable-multilib --with-cmodel=medany ${ARCH:+--with-arch=${ARCH}}
 module_make riscv-gnu-toolchain linux
 
 echo "Toolchain Build Complete!"


### PR DESCRIPTION
Hi All, 
This feedstock is mainly for providing precompiled riscv toolchain for Chipyard. Since there are RV32 cores supported by Chipyard(RocketChip has RV32 configuration and the educational SODAR core), I wonder if riscv toolchain provided by the default chipyard configuration could provide multilib support so that some of the evaluation design could be compiled successfully without using some extra toolchains(from sifive or others). But according to https://github.com/ucb-bar/chipyard/pull/372, seems that enabling multilib just by appending _`--enable-multilib`_ in the configure will break some libraries. I don't know if this is true for the current chipyard software stack. Therefore I filed this PR mainly for requesting a chipyard riscv toolchain for both RV32 and RV64 support. If the multilib support is not reasonable, is there some other mechanism to make this happen?
Thanks!