### PR TITLE
Update meta.yaml for python_abi dep. ignore

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ requirements:
   ignore_run_exports:
     # nothing links against libpython, the build scripts just don't work out
     # of the box if you split the libs into build/host
-    - python
+    - python_abi
 
 test:
   commands:


### PR DESCRIPTION
![image](https://github.com/ucb-bar/riscv-tools-feedstock/assets/8823803/69c5ddf5-4916-4a2f-ab01-7994ab7286d8)
 ^ I see the following when looking at the info for the package. It has an erroneous `python_abi` runtime dep. that causes issues if you bump Python. 