### PR TITLE
Don't pin bison version, let resolver pick

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,7 @@ requirements:
 
     - sysroot_linux-64 2.17 # [linux64]
 
-    # if building riscv-toolchain from source, we need to use bison==3.4.* until we have
-    # https://github.com/riscv-collab/riscv-binutils-gdb/commit/314ec7aeeb1b2e68f0d8fb9990f2335f475a6e33
-    - bison==3.4.* # note: doing =3.4 doesn't work
+    - bison>=3.4.0
 
     - make
     - autoconf


### PR DESCRIPTION
Allow the resolver to pick a newer version of bison